### PR TITLE
Rename componentWillReceiveProps to UNSAFE_componentWillReceiveProps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -110,7 +110,7 @@ class Interactive extends React.Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     // set if the `topNode` needs to be updated in componentDidUpdate => `as` is different
     // and not a string, note that if `as` is a new string, then the `refCallback`
     // will be called by React so no need to do anything in componentDidUpdate


### PR DESCRIPTION
This suppresses a console warning in React 16.9 and will be required for React 17.x.

The console warning:
```
Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://fb.me/react-async-component-lifecycle-hooks for details.

* Move data fetching code or side effects to componentDidUpdate.
* If you're updating state whenever props change, refactor your code to use memoization techniques or move it to static getDerivedStateFromProps. Learn more at: https://fb.me/react-derived-state
* Rename componentWillReceiveProps to UNSAFE_componentWillReceiveProps to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.

Please update the following components: Interactive
```